### PR TITLE
Typo; "securtityContext"

### DIFF
--- a/install_config/persistent_storage/persistent_storage_nfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_nfs.adoc
@@ -270,7 +270,7 @@ spec:
     securityContext:
       runAsUser: 65534 <2>
 ----
-<1> Pods contain a `*securtityContext*` specific to each container (shown here) and
+<1> Pods contain a `*securityContext*` specific to each container (shown here) and
 a pod-level `*securityContext*` which applies to all containers defined in the pod.
 <2> 65534 is the *nfsnobody* user.
 ====


### PR DESCRIPTION
Typo "securtityContext" -> "securityContext".